### PR TITLE
Fix build and output writing errors

### DIFF
--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/DataSetClassification.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/DataSetClassification.java
@@ -10,7 +10,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.table.*;
 import cz.crcs.sekan.rsakeysanalysis.classification.tests.ModulusFactors;
 import cz.crcs.sekan.rsakeysanalysis.common.ExtendedWriter;
 import cz.crcs.sekan.rsakeysanalysis.template.Template;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/Classification.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/Classification.java
@@ -374,7 +374,12 @@ public class Classification<BatchProperty> {
             System.out.println(String.format("Saved statistics in %d seconds", (System.currentTimeMillis() - time) / 1000));
 
         time = System.currentTimeMillis();
-        dataSetSaver.reconstructDataSet(batchHolder, keyIdToKeyStub);
+        try {
+            dataSetSaver.reconstructDataSet(batchHolder, keyIdToKeyStub);
+        } catch (IOException e) {
+            System.err.println("Couldn't save dataset result to file");
+            e.printStackTrace();
+        }
         if (makeOutputs)
             System.out.println(String.format("Saved annotated dataset in %d seconds", (System.currentTimeMillis() - time) / 1000));
         return priorProbabilityEstimator;

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/dataset/DataSetSaver.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/dataset/DataSetSaver.java
@@ -5,6 +5,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.key.ClassificationKey;
 import cz.crcs.sekan.rsakeysanalysis.classification.key.ClassificationKeyStub;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.ClassificationContainer;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -14,5 +15,5 @@ import java.util.Map;
 public interface DataSetSaver {
     public void registerKeyUnderKeyId(ClassificationKey key, Long keyId);
     public void setBatchClassificationResult(Long batchId, ClassificationContainer classificationContainer);
-    public void reconstructDataSet(BatchHolder batchHolder, Map<Long, ClassificationKeyStub> keyIdToKeyStub);
+    public void reconstructDataSet(BatchHolder batchHolder, Map<Long, ClassificationKeyStub> keyIdToKeyStub) throws IOException;
 }

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/dataset/FromFileDataSetSaver.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/dataset/FromFileDataSetSaver.java
@@ -47,7 +47,7 @@ public class FromFileDataSetSaver implements DataSetSaver {
     }
 
     @Override
-    public void reconstructDataSet(BatchHolder batchHolder, Map<Long, ClassificationKeyStub> keyIdToKeyStub) {
+    public void reconstructDataSet(BatchHolder batchHolder, Map<Long, ClassificationKeyStub> keyIdToKeyStub) throws IOException {
         while (dataSetIterator.hasNext()) {
             ClassificationKey key = dataSetIterator.next();
             Long keyId = keyModulusToKeyId.get(key.getShortenedModulus());
@@ -62,6 +62,7 @@ public class FromFileDataSetSaver implements DataSetSaver {
                 System.err.println("Could not save result of classification: " + e.getMessage());
             }
         }
+        resultWriter.flush();
         dataSetIterator.close();
     }
 }

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/dataset/InMemoryDataSetSaver.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/dataset/InMemoryDataSetSaver.java
@@ -39,7 +39,7 @@ public class InMemoryDataSetSaver implements DataSetSaver {
     }
 
     @Override
-    public void reconstructDataSet(BatchHolder batchHolder, Map<Long, ClassificationKeyStub> keyIdToKeyStub) {
+    public void reconstructDataSet(BatchHolder batchHolder, Map<Long, ClassificationKeyStub> keyIdToKeyStub) throws IOException {
         for (Long keyId : keyIdToClassificationKey.keySet()) {
             ClassificationKey key = keyIdToClassificationKey.get(keyId);
             ClassificationContainer container = batchIdToClassificationContainer.get(batchHolder.getBatchIdForKeyId(keyId));
@@ -51,5 +51,6 @@ public class InMemoryDataSetSaver implements DataSetSaver {
                 System.err.println("Could not save result of classification: " + e.getMessage());
             }
         }
+        resultWriter.flush();
     }
 }

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/statistics/HistoricalBatchesStatisticsAggregator.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/algorithm/statistics/HistoricalBatchesStatisticsAggregator.java
@@ -5,7 +5,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.key.ClassificationKeyStub;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.ClassificationContainer;
 import cz.crcs.sekan.rsakeysanalysis.common.ExtendedWriter;
 import cz.crcs.sekan.rsakeysanalysis.template.Template;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/table/ClassificationTable.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/table/ClassificationTable.java
@@ -4,8 +4,6 @@ import cz.crcs.sekan.rsakeysanalysis.classification.algorithm.apriori.PriorProba
 import cz.crcs.sekan.rsakeysanalysis.classification.key.ClassificationKey;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.identification.IdentificationGenerator;
 import cz.crcs.sekan.rsakeysanalysis.common.ExtendedWriter;
-import javafx.util.Pair;
-import org.omg.CORBA.INTERNAL;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/table/RawTable.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/table/RawTable.java
@@ -6,7 +6,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.excepti
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongTransformationFormatException;
 import cz.crcs.sekan.rsakeysanalysis.common.ExtendedWriter;
 import cz.crcs.sekan.rsakeysanalysis.common.GroupsComparator;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/table/transformation/CombinationTransformation.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/table/transformation/CombinationTransformation.java
@@ -4,11 +4,10 @@ import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.excepti
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongOptionsFormatException;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongTransformationFormatException;
 import cz.crcs.sekan.rsakeysanalysis.common.RSAKey;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
-import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/table/transformation/LexicographicOrderTransformation.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/table/transformation/LexicographicOrderTransformation.java
@@ -5,7 +5,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.excepti
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongOptionsFormatException;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongTransformationFormatException;
 import cz.crcs.sekan.rsakeysanalysis.common.RSAKey;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/tests/ClassificationSuccess.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/tests/ClassificationSuccess.java
@@ -7,7 +7,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.table.RawTable;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.TransformationNotFoundException;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongTransformationFormatException;
 import cz.crcs.sekan.rsakeysanalysis.common.ExtendedWriter;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 import org.json.simple.parser.ParseException;
 
 import java.io.IOException;

--- a/src/cz/crcs/sekan/rsakeysanalysis/classification/tests/LegacyMisclassification.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/classification/tests/LegacyMisclassification.java
@@ -7,7 +7,7 @@ import cz.crcs.sekan.rsakeysanalysis.classification.table.RawTable;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.TransformationNotFoundException;
 import cz.crcs.sekan.rsakeysanalysis.classification.table.transformation.exception.WrongTransformationFormatException;
 import cz.crcs.sekan.rsakeysanalysis.common.ExtendedWriter;
-import javafx.util.Pair;
+import cz.crcs.sekan.rsakeysanalysis.util.Pair;
 import org.json.simple.parser.ParseException;
 
 import java.io.IOException;

--- a/src/cz/crcs/sekan/rsakeysanalysis/common/ExtendedWriter.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/common/ExtendedWriter.java
@@ -22,4 +22,10 @@ public class ExtendedWriter extends BufferedWriter {
         write(line);
         newLine();
     }
+
+    @Override
+    public void close() throws IOException {
+        super.flush();
+        super.close();
+    }
 }

--- a/src/cz/crcs/sekan/rsakeysanalysis/tools/RemoveDuplicity.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/tools/RemoveDuplicity.java
@@ -1,9 +1,6 @@
 package cz.crcs.sekan.rsakeysanalysis.tools;
 
 import cz.crcs.sekan.rsakeysanalysis.classification.key.ClassificationKey;
-import javafx.util.Pair;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 
 import java.io.*;
 import java.math.BigInteger;

--- a/src/cz/crcs/sekan/rsakeysanalysis/util/Pair.java
+++ b/src/cz/crcs/sekan/rsakeysanalysis/util/Pair.java
@@ -1,0 +1,28 @@
+package cz.crcs.sekan.rsakeysanalysis.util;
+
+public class Pair<K,V> {
+
+    private K key;
+    private V value;
+
+    public Pair(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public void setKey(K key) {
+        this.key = key;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    public void setValue(V value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
* Remove unused import from unavailable dependencies (org.omg.CORBA).
* Add own implementation of Pair to remove dependency on javafx.util.Pair.
* Flush file writers. The file writers (most notably the dataset saver)
were not flushed after writing, causing output to be truncated. Flushing
them after writing (or upon closing) fixes this issue.
* With these changes, the ant script will run successfully and allow building
the jar correctly again. :)